### PR TITLE
Fix/container

### DIFF
--- a/examples/callback-validation/validation_examples.py
+++ b/examples/callback-validation/validation_examples.py
@@ -11,14 +11,15 @@ from typing import Any
 from pyagenity.graph import StateGraph
 from pyagenity.state import AgentState
 from pyagenity.utils import (
+    AfterInvokeCallback,
+    BeforeInvokeCallback,
     CallbackContext,
     CallbackManager,
     InvocationType,
-    BeforeInvokeCallback,
-    AfterInvokeCallback,
-    OnErrorCallback,
     Message,
+    OnErrorCallback,
 )
+
 
 # Configure logging for examples
 logging.basicConfig(

--- a/examples/react-injection/react_di.py
+++ b/examples/react-injection/react_di.py
@@ -1,0 +1,171 @@
+from dotenv import load_dotenv
+from injectq import Inject, InjectQ, inject, injectq
+
+from pyagenity.checkpointer import InMemoryCheckpointer
+from pyagenity.checkpointer.base_checkpointer import BaseCheckpointer
+from pyagenity.graph import StateGraph, ToolNode
+from pyagenity.state.agent_state import AgentState
+from pyagenity.store.base_store import BaseStore
+from pyagenity.utils import Message
+from pyagenity.utils.callbacks import CallbackManager
+from pyagenity.utils.constants import END
+from pyagenity.utils.converter import convert_messages
+
+
+load_dotenv()
+
+checkpointer = InMemoryCheckpointer()
+
+
+@inject
+def get_weather(
+    location: str,
+    tool_call_id: str,
+    state: AgentState,
+    config: dict,
+) -> Message:
+    """
+    Get the current weather for a specific location.
+    This demo shows injectable parameters: tool_call_id and state are automatically injected.
+    """
+    # You can access injected parameters here
+    if tool_call_id:
+        print(f"Tool call ID: {tool_call_id}")
+    if state and hasattr(state, "context"):
+        print(f"Number of messages in context: {len(state.context)}")  # type: ignore
+
+    res = f"The weather in {location} is sunny"
+    return Message.tool_message(
+        content=res,
+        tool_call_id=tool_call_id,  # type: ignore
+    )
+
+
+tool_node = ToolNode([get_weather])
+
+
+async def main_agent(
+    # state: AgentState,
+    # config: dict,
+    callback: CallbackManager = Inject[CallbackManager],
+    # checkpointer: InMemoryCheckpointer | None = None,
+    # store: BaseStore | None = None,
+):
+    prompts = """
+        You are a helpful assistant.
+        Your task is to assist the user in finding information and answering questions.
+    """
+
+    # messages = convert_messages(
+    #     system_prompts=[{"role": "system", "content": prompts}],
+    #     state=state,
+    # )
+
+    mcp_tools = []
+
+    # # Check if the last message is a tool result - if so, make final response without tools
+    # if (
+    #     state.context
+    #     and len(state.context) > 0
+    #     and state.context[-1].role == "tool"
+    #     and state.context[-1].tool_call_id is not None
+    # ):
+    #     # Make final response without tools since we just got tool results
+    #     response = await acompletion(
+    #         model="gemini/gemini-2.5-flash",
+    #         messages=messages,
+    #     )
+    # else:
+    #     # Regular response with tools available
+    #     tools = await tool_node.all_tools()
+    #     response = await acompletion(
+    #         model="gemini/gemini-2.5-flash",
+    #         messages=messages,
+    #         tools=tools + mcp_tools,
+    #     )
+
+    message_id = injectq.get("generated_id")
+    # message_id2 = injectq.try_get("generated_id2", "final-response-579898")
+    # print("Generated Message ID: ", message_id)
+    # print("Generated Message ID 2: ", message_id2)
+    print("checkpointer", checkpointer)
+    # print("state", state)
+    print("config", config)
+    # print("State", len(state.context))
+    # print("Store", store)
+    # print("Callback", callback)
+
+    return Message(
+        message_id="final-response-579898",
+        content="This is example final response from main agent.",
+        role="assistant",
+        tools_calls=[],
+    )
+
+
+def should_use_tools(state: AgentState) -> str:
+    """Determine if we should use tools or end the conversation."""
+    if not state.context or len(state.context) == 0:
+        return "TOOL"  # No context, might need tools
+
+    last_message = state.context[-1]
+
+    # If the last message is from assistant and has tool calls, go to TOOL
+    if (
+        hasattr(last_message, "tools_calls")
+        and last_message.tools_calls
+        and len(last_message.tools_calls) > 0
+        and last_message.role == "assistant"
+    ):
+        return "TOOL"
+
+    # If last message is a tool result, we should be done (AI will make final response)
+    if last_message.role == "tool" and last_message.tool_call_id is not None:
+        return END
+
+    # Default to END for other cases
+    return END
+
+
+injectq["generated_id2"] = "main-response-12345"
+
+graph = StateGraph(container=None)
+graph.add_node("MAIN", main_agent)
+graph.add_node("TOOL", tool_node)
+
+# Add conditional edges from MAIN
+graph.add_conditional_edges(
+    "MAIN",
+    should_use_tools,
+    {"TOOL": "TOOL", END: END},
+)
+
+# Always go back to MAIN after TOOL execution
+graph.add_edge("TOOL", "MAIN")
+graph.set_entry_point("MAIN")
+
+
+app = graph.compile(
+    checkpointer=checkpointer,
+)
+
+
+# now run it
+
+inp = {"messages": [Message.from_text("Please call the get_weather function for New York City")]}
+config = {"thread_id": "12345", "recursion_limit": 10}
+
+print("***** GRAPH", injectq.get_dependency_graph())
+res = app.invoke(inp, config=config)
+
+for i in res["messages"]:
+    print("**********************")
+    print("Message Type: ", i.role)
+    print(i)
+    print("**********************")
+    print("\n\n")
+
+
+# grp = app.generate_graph()
+
+# print(grp)

--- a/examples/react/react_weather_agent.py
+++ b/examples/react/react_weather_agent.py
@@ -1,7 +1,4 @@
-from typing import Any
-
 from dotenv import load_dotenv
-from injectq import inject
 from litellm import acompletion
 
 from pyagenity.checkpointer import InMemoryCheckpointer
@@ -17,7 +14,6 @@ load_dotenv()
 checkpointer = InMemoryCheckpointer()
 
 
-@inject
 def get_weather(
     location: str,
     tool_call_id: str | None = None,

--- a/examples/react_stream/stream_react_agent.py
+++ b/examples/react_stream/stream_react_agent.py
@@ -11,7 +11,6 @@ from pyagenity.state.agent_state import AgentState
 from pyagenity.utils import Message, ResponseGranularity
 from pyagenity.utils.constants import END
 from pyagenity.utils.converter import convert_messages
-from pyagenity.utils.injectable import InjectState, InjectToolCallID
 
 
 load_dotenv()
@@ -21,8 +20,8 @@ checkpointer = InMemoryCheckpointer()
 
 def get_weather(
     location: str,
-    tool_call_id: InjectToolCallID,
-    state: InjectState,
+    tool_call_id: str,
+    state: AgentState,
 ) -> Message:
     """
     Get the current weather for a specific location.
@@ -109,7 +108,7 @@ async def main_agent(
             model="gemini/gemini-2.5-flash",
             messages=messages,
             tools=tools + mcp_tools,
-            stream=False,
+            stream=True,
         )
 
     return response

--- a/pyagenity/graph/compiled_graph.py
+++ b/pyagenity/graph/compiled_graph.py
@@ -124,6 +124,8 @@ class CompiledGraph[StateT: AgentState]:
         """
         cfg = config or {}
         cfg["is_stream"] = False
+        if "user_id" not in cfg:
+            cfg["user_id"] = "test_user"
 
         return await self.invoke_handler.invoke(
             input_data,
@@ -198,6 +200,8 @@ class CompiledGraph[StateT: AgentState]:
 
         cfg = config or {}
         cfg["is_stream"] = False
+        if "user_id" not in cfg:
+            cfg["user_id"] = "test_user"
 
         return self.stream_handler.stream(
             input_data,

--- a/pyagenity/graph/invoke_handler.py
+++ b/pyagenity/graph/invoke_handler.py
@@ -10,10 +10,8 @@ from pyagenity.publisher import BasePublisher, Event, EventType, SourceType
 from pyagenity.state import AgentState, ExecutionStatus
 from pyagenity.utils import (
     END,
-    CallbackManager,
     Message,
     ResponseGranularity,
-    default_callback_manager,
 )
 
 from .edge import Edge
@@ -190,7 +188,7 @@ class InvokeHandler[StateT: AgentState]:
                 ##### Node Execution Started ##################
                 ###############################################
 
-                result = await node.execute(config, state)
+                result = await node.execute(config, state)  # type: ignore
 
                 ###############################################
                 ##### Node Execution Finished #################

--- a/pyagenity/graph/state_graph.py
+++ b/pyagenity/graph/state_graph.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, TypeVar, Union
 
-from injectq import InjectQ, injectq
+from injectq import InjectQ
 from injectq.core.context import ContainerContext
 
 from pyagenity.checkpointer import BaseCheckpointer
@@ -116,11 +116,13 @@ class StateGraph[StateT: AgentState]:
         # save container for dependency injection
         # if any container is passed then we will activate that
         # otherwise we can skip it and use the default one
-        if container:
-            self._container = container
-            ContainerContext.set_current(container)
+        if container is None:
+            self._container = InjectQ.get_instance()
+            logger.debug("No container provided, using global singleton instance")
         else:
-            self._container = injectq
+            logger.debug("Using provided dependency container instance")
+            self._container = container
+            ContainerContext.set_current(self._container)
 
         # now setup the graph
         self._setup()

--- a/pyagenity/graph/state_graph.py
+++ b/pyagenity/graph/state_graph.py
@@ -147,6 +147,7 @@ class StateGraph[StateT: AgentState]:
         # register id generator as factory
         self._container.bind(BaseIDGenerator, self._id_generator)
         self._container.bind("generated_id_type", self._id_generator.id_type)
+        # Allow async method also
         self._container.bind_factory(
             "generated_id",
             lambda: self._id_generator.generate(),
@@ -296,7 +297,6 @@ class StateGraph[StateT: AgentState]:
         self,
         checkpointer: BaseCheckpointer[StateT] | None = None,
         store: BaseStore | None = None,
-        context_manager: BaseContextManager[StateT] | None = None,
         interrupt_before: list[str] | None = None,
         interrupt_after: list[str] | None = None,
     ) -> "CompiledGraph[StateT]":

--- a/pyagenity/graph/tool_node.py
+++ b/pyagenity/graph/tool_node.py
@@ -40,7 +40,6 @@ from pyagenity.utils import (
     CallbackManager,
     InvocationType,
     call_sync_or_async,
-    default_callback_manager,
 )
 from pyagenity.utils.message import Message
 
@@ -410,7 +409,7 @@ class ToolNode:
         tool_call_id: str,
         config: dict[str, t.Any],
         state: AgentState,
-        callback_manager: CallbackManager | None = None,  # type: ignore
+        callback_manager: CallbackManager,  # type: ignore
     ) -> t.Any:
         """Execute the callable registered under `name` with `args` kwargs.
 
@@ -424,8 +423,6 @@ class ToolNode:
         """
         logger.info("Executing tool '%s' with %d arguments", name, len(args))
         logger.debug("Tool arguments: %s", args)
-
-        callback_manager = callback_manager or default_callback_manager
 
         # check in mcp
         if name in self.mcp_tools:

--- a/pyagenity/publisher/redis_publisher.py
+++ b/pyagenity/publisher/redis_publisher.py
@@ -19,6 +19,7 @@ from typing import Any
 from .base_publisher import BasePublisher
 from .events import Event
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/pyagenity/utils/id_generator.py
+++ b/pyagenity/utils/id_generator.py
@@ -9,6 +9,7 @@ import enum
 import secrets
 import string
 import time
+from typing import Awaitable
 import uuid
 from abc import ABC, abstractmethod
 
@@ -41,7 +42,7 @@ class BaseIDGenerator(ABC):
         raise NotImplementedError("id_type method must be implemented")
 
     @abstractmethod
-    def generate(self) -> str | int:
+    def generate(self) -> str | int | Awaitable[str | int]:
         """Generate a new unique ID.
 
         Returns:
@@ -203,3 +204,26 @@ class ShortIDGenerator(BaseIDGenerator):
         """
         alphabet = string.ascii_letters + string.digits
         return "".join(secrets.choice(alphabet) for _ in range(8))
+
+
+class AsyncIDGenerator(BaseIDGenerator):
+    """ID generator that produces UUID version 4 strings asynchronously.
+
+    UUIDs are 128-bit identifiers that are virtually guaranteed to be unique
+    across space and time. The generated strings are 36 characters long
+    (32 hexadecimal digits + 4 hyphens in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).
+    This generator provides an asynchronous interface for generating UUIDs.
+    """
+
+    @property
+    def id_type(self) -> IDType:
+        return IDType.STRING
+
+    async def generate(self) -> str:
+        """Asynchronously generate a new UUID4 string.
+
+        Returns:
+            str: A 36-character UUID string (e.g., '550e8400-e29b-41d4-a716-446655440000').
+        """
+        # Simulate async operation (e.g., if fetching from an external service)
+        return str(uuid.uuid4())

--- a/pyagenity/utils/id_generator.py
+++ b/pyagenity/utils/id_generator.py
@@ -13,6 +13,9 @@ import uuid
 from abc import ABC, abstractmethod
 
 
+# TODO: Allow async also
+
+
 class IDType(enum.StrEnum):
     """Enumeration of supported ID types."""
 

--- a/pyagenity/utils/message.py
+++ b/pyagenity/utils/message.py
@@ -1,5 +1,7 @@
 # Default message representation
+import asyncio
 import logging
+from collections.abc import Awaitable
 from datetime import datetime
 from typing import Any, Literal
 from uuid import uuid4
@@ -15,6 +17,15 @@ logger = logging.getLogger(__name__)
 def generate_id(default_id: str | int | None) -> str | int:
     id_type = injectq.try_get("generated_id_type", "string")
     generated_id = injectq.try_get("generated_id", None)
+
+    # if user provided an awaitable, resolve it
+    if isinstance(generated_id, Awaitable):
+
+        async def wait_for_id():
+            return await generated_id
+
+        generated_id = asyncio.run(wait_for_id())
+
     if generated_id:
         return generated_id
 

--- a/pyagenity/utils/message.py
+++ b/pyagenity/utils/message.py
@@ -89,44 +89,6 @@ class Message(BaseModel):
     usages: TokenUsages | None = None
     raw: dict[str, Any] | None = None
 
-    # def to_dict(self, include_raw: bool = False) -> dict[str, Any]:
-    #     """
-    #     Convert the Message instance to a dictionary with all fields.
-
-    #     Args:
-    #         include_raw (bool): Whether to include the raw field in the output.
-
-    #     Returns:
-    #         dict[str, Any]: Dictionary representation of the message.
-    #     """
-    #     data = self.model_dump()
-
-    #     # Handle timestamp formatting
-    #     ts = data.get("timestamp")
-    #     if ts is None:
-    #         ts_val = None
-    #     elif hasattr(ts, "isoformat"):
-    #         ts_val = ts.isoformat()
-    #     elif isinstance(ts, int):
-    #         ts_val = ts  # leave as int (epoch)
-    #     else:
-    #         ts_val = str(ts)
-
-    #     result = {
-    #         "message_id": data["message_id"],
-    #         "role": data["role"],
-    #         "content": data["content"],
-    #         "reasoning": data["reasoning"],
-    #         "timestamp": ts_val,
-    #         "metadata": data["metadata"],
-    #         "usages": self.usages.to_dict() if self.usages else None,
-    #     }
-
-    #     if include_raw:
-    #         result["raw"] = data["raw"]
-
-    #     return result
-
     @classmethod
     def from_text(
         cls,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
-    "injectq>=0.1.0",
+    "injectq==0.2.0",
     "litellm>=1.75.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,49 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/4c/7c991e080e106d854809030d8584e15b2e996e26f16aee6d757e387bc17d/asyncpg-0.30.0.tar.gz", hash = "sha256:c551e9928ab6707602f44811817f82ba3c446e018bfe1d3abecc8ba5f3eac851", size = 957746, upload-time = "2024-10-20T00:30:41.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/07/1650a8c30e3a5c625478fa8aafd89a8dd7d85999bf7169b16f54973ebf2c/asyncpg-0.30.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bfb4dd5ae0699bad2b233672c8fc5ccbd9ad24b89afded02341786887e37927e", size = 673143, upload-time = "2024-10-20T00:29:08.846Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9a/568ff9b590d0954553c56806766914c149609b828c426c5118d4869111d3/asyncpg-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc1f62c792752a49f88b7e6f774c26077091b44caceb1983509edc18a2222ec0", size = 645035, upload-time = "2024-10-20T00:29:12.02Z" },
+    { url = "https://files.pythonhosted.org/packages/de/11/6f2fa6c902f341ca10403743701ea952bca896fc5b07cc1f4705d2bb0593/asyncpg-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3152fef2e265c9c24eec4ee3d22b4f4d2703d30614b0b6753e9ed4115c8a146f", size = 2912384, upload-time = "2024-10-20T00:29:13.644Z" },
+    { url = "https://files.pythonhosted.org/packages/83/83/44bd393919c504ffe4a82d0aed8ea0e55eb1571a1dea6a4922b723f0a03b/asyncpg-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7255812ac85099a0e1ffb81b10dc477b9973345793776b128a23e60148dd1af", size = 2947526, upload-time = "2024-10-20T00:29:15.871Z" },
+    { url = "https://files.pythonhosted.org/packages/08/85/e23dd3a2b55536eb0ded80c457b0693352262dc70426ef4d4a6fc994fa51/asyncpg-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:578445f09f45d1ad7abddbff2a3c7f7c291738fdae0abffbeb737d3fc3ab8b75", size = 2895390, upload-time = "2024-10-20T00:29:19.346Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/26/fa96c8f4877d47dc6c1864fef5500b446522365da3d3d0ee89a5cce71a3f/asyncpg-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c42f6bb65a277ce4d93f3fba46b91a265631c8df7250592dd4f11f8b0152150f", size = 3015630, upload-time = "2024-10-20T00:29:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/34/00/814514eb9287614188a5179a8b6e588a3611ca47d41937af0f3a844b1b4b/asyncpg-0.30.0-cp310-cp310-win32.whl", hash = "sha256:aa403147d3e07a267ada2ae34dfc9324e67ccc4cdca35261c8c22792ba2b10cf", size = 568760, upload-time = "2024-10-20T00:29:22.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/28/869a7a279400f8b06dd237266fdd7220bc5f7c975348fea5d1e6909588e9/asyncpg-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb622c94db4e13137c4c7f98834185049cc50ee01d8f657ef898b6407c7b9c50", size = 625764, upload-time = "2024-10-20T00:29:25.882Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0e/f5d708add0d0b97446c402db7e8dd4c4183c13edaabe8a8500b411e7b495/asyncpg-0.30.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5e0511ad3dec5f6b4f7a9e063591d407eee66b88c14e2ea636f187da1dcfff6a", size = 674506, upload-time = "2024-10-20T00:29:27.988Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a0/67ec9a75cb24a1d99f97b8437c8d56da40e6f6bd23b04e2f4ea5d5ad82ac/asyncpg-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:915aeb9f79316b43c3207363af12d0e6fd10776641a7de8a01212afd95bdf0ed", size = 645922, upload-time = "2024-10-20T00:29:29.391Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d9/a7584f24174bd86ff1053b14bb841f9e714380c672f61c906eb01d8ec433/asyncpg-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c198a00cce9506fcd0bf219a799f38ac7a237745e1d27f0e1f66d3707c84a5a", size = 3079565, upload-time = "2024-10-20T00:29:30.832Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/a4c0f9660e333114bdb04d1a9ac70db690dd4ae003f34f691139a5cbdae3/asyncpg-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3326e6d7381799e9735ca2ec9fd7be4d5fef5dcbc3cb555d8a463d8460607956", size = 3109962, upload-time = "2024-10-20T00:29:33.114Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/199fd16b5a981b1575923cbb5d9cf916fdc936b377e0423099f209e7e73d/asyncpg-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:51da377487e249e35bd0859661f6ee2b81db11ad1f4fc036194bc9cb2ead5056", size = 3064791, upload-time = "2024-10-20T00:29:34.677Z" },
+    { url = "https://files.pythonhosted.org/packages/77/52/0004809b3427534a0c9139c08c87b515f1c77a8376a50ae29f001e53962f/asyncpg-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bc6d84136f9c4d24d358f3b02be4b6ba358abd09f80737d1ac7c444f36108454", size = 3188696, upload-time = "2024-10-20T00:29:36.389Z" },
+    { url = "https://files.pythonhosted.org/packages/52/cb/fbad941cd466117be58b774a3f1cc9ecc659af625f028b163b1e646a55fe/asyncpg-0.30.0-cp311-cp311-win32.whl", hash = "sha256:574156480df14f64c2d76450a3f3aaaf26105869cad3865041156b38459e935d", size = 567358, upload-time = "2024-10-20T00:29:37.915Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0a/0a32307cf166d50e1ad120d9b81a33a948a1a5463ebfa5a96cc5606c0863/asyncpg-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:3356637f0bd830407b5597317b3cb3571387ae52ddc3bca6233682be88bbbc1f", size = 629375, upload-time = "2024-10-20T00:29:39.987Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/64/9d3e887bb7b01535fdbc45fbd5f0a8447539833b97ee69ecdbb7a79d0cb4/asyncpg-0.30.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c902a60b52e506d38d7e80e0dd5399f657220f24635fee368117b8b5fce1142e", size = 673162, upload-time = "2024-10-20T00:29:41.88Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/eb/8b236663f06984f212a087b3e849731f917ab80f84450e943900e8ca4052/asyncpg-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aca1548e43bbb9f0f627a04666fedaca23db0a31a84136ad1f868cb15deb6e3a", size = 637025, upload-time = "2024-10-20T00:29:43.352Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/57/2dc240bb263d58786cfaa60920779af6e8d32da63ab9ffc09f8312bd7a14/asyncpg-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c2a2ef565400234a633da0eafdce27e843836256d40705d83ab7ec42074efb3", size = 3496243, upload-time = "2024-10-20T00:29:44.922Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/40/0ae9d061d278b10713ea9021ef6b703ec44698fe32178715a501ac696c6b/asyncpg-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1292b84ee06ac8a2ad8e51c7475aa309245874b61333d97411aab835c4a2f737", size = 3575059, upload-time = "2024-10-20T00:29:46.891Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/75/d6b895a35a2c6506952247640178e5f768eeb28b2e20299b6a6f1d743ba0/asyncpg-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f5712350388d0cd0615caec629ad53c81e506b1abaaf8d14c93f54b35e3595a", size = 3473596, upload-time = "2024-10-20T00:29:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e7/3693392d3e168ab0aebb2d361431375bd22ffc7b4a586a0fc060d519fae7/asyncpg-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db9891e2d76e6f425746c5d2da01921e9a16b5a71a1c905b13f30e12a257c4af", size = 3641632, upload-time = "2024-10-20T00:29:50.768Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ea/15670cea95745bba3f0352341db55f506a820b21c619ee66b7d12ea7867d/asyncpg-0.30.0-cp312-cp312-win32.whl", hash = "sha256:68d71a1be3d83d0570049cd1654a9bdfe506e794ecc98ad0873304a9f35e411e", size = 560186, upload-time = "2024-10-20T00:29:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/6b/fe1fad5cee79ca5f5c27aed7bd95baee529c1bf8a387435c8ba4fe53d5c1/asyncpg-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:9a0292c6af5c500523949155ec17b7fe01a00ace33b68a476d6b5059f9630305", size = 621064, upload-time = "2024-10-20T00:29:53.757Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/22/e20602e1218dc07692acf70d5b902be820168d6282e69ef0d3cb920dc36f/asyncpg-0.30.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05b185ebb8083c8568ea8a40e896d5f7af4b8554b64d7719c0eaa1eb5a5c3a70", size = 670373, upload-time = "2024-10-20T00:29:55.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/0cf269a9d647852a95c06eb00b815d0b95a4eb4b55aa2d6ba680971733b9/asyncpg-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c47806b1a8cbb0a0db896f4cd34d89942effe353a5035c62734ab13b9f938da3", size = 634745, upload-time = "2024-10-20T00:29:57.14Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6d/a4f31bf358ce8491d2a31bfe0d7bcf25269e80481e49de4d8616c4295a34/asyncpg-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b6fde867a74e8c76c71e2f64f80c64c0f3163e687f1763cfaf21633ec24ec33", size = 3512103, upload-time = "2024-10-20T00:29:58.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/19/139227a6e67f407b9c386cb594d9628c6c78c9024f26df87c912fabd4368/asyncpg-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46973045b567972128a27d40001124fbc821c87a6cade040cfcd4fa8a30bcdc4", size = 3592471, upload-time = "2024-10-20T00:30:00.354Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e4/ab3ca38f628f53f0fd28d3ff20edff1c975dd1cb22482e0061916b4b9a74/asyncpg-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9110df111cabc2ed81aad2f35394a00cadf4f2e0635603db6ebbd0fc896f46a4", size = 3496253, upload-time = "2024-10-20T00:30:02.794Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5f/0bf65511d4eeac3a1f41c54034a492515a707c6edbc642174ae79034d3ba/asyncpg-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04ff0785ae7eed6cc138e73fc67b8e51d54ee7a3ce9b63666ce55a0bf095f7ba", size = 3662720, upload-time = "2024-10-20T00:30:04.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/31/1513d5a6412b98052c3ed9158d783b1e09d0910f51fbe0e05f56cc370bc4/asyncpg-0.30.0-cp313-cp313-win32.whl", hash = "sha256:ae374585f51c2b444510cdf3595b97ece4f233fde739aa14b50e0d64e8a7a590", size = 560404, upload-time = "2024-10-20T00:30:06.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a4/cec76b3389c4c5ff66301cd100fe88c318563ec8a520e0b2e792b5b84972/asyncpg-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:f59b430b8e27557c3fb9869222559f7417ced18688375825f8f12302c34e915e", size = 621623, upload-time = "2024-10-20T00:30:09.024Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -845,16 +888,14 @@ wheels = [
 
 [[package]]
 name = "injectq"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "taskiq" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/07/59123dd1ca6d2c4f7fa438932dcd5c7f881af449601cbaa9db2abb60ec80/injectq-0.1.0.tar.gz", hash = "sha256:30aff802f68829b9ced1c08744a632accd7717b8212e807489a780b8402985be", size = 2850822, upload-time = "2025-09-03T13:19:58.07Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/dd/b17d2953efe510d0cce47e06644d3e9b8034734c16ccfb1d19e08f0159de/injectq-0.2.0.tar.gz", hash = "sha256:cce88b5dece4d7c8de1ebad5b0764111705a810c033b8dc62d87f745dc7c373b", size = 510951, upload-time = "2025-09-06T08:55:53.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/30/afebd6f4a9d827cf69f82998467420bc312e193886e9c62d9cafee17dbed/injectq-0.1.0-py3-none-any.whl", hash = "sha256:e7db177398169167ac1053f13163f26cc13ba79272edf97b68bdbc376d80b19e", size = 57026, upload-time = "2025-09-03T13:19:54.435Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d0/7df3e51ca2d54d32e4af8013b549799534c9db2a45165ce3af4f5ab68d26/injectq-0.2.0-py3-none-any.whl", hash = "sha256:c3ba7504d38ac376d74d0884b321a3ea72602d554e45306912a9172520ebd23b", size = 62446, upload-time = "2025-09-06T08:55:50.966Z" },
 ]
 
 [[package]]
@@ -864,15 +905,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
-]
-
-[[package]]
-name = "izulu"
-version = "0.50.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/58/6d6335c78b7ade54d8a6c6dbaa589e5c21b3fd916341d5a16f774c72652a/izulu-0.50.0.tar.gz", hash = "sha256:cc8e252d5e8560c70b95380295008eeb0786f7b745a405a40d3556ab3252d5f5", size = 48558, upload-time = "2025-03-24T15:52:21.51Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/9f/bf9d33546bbb6e5e80ebafe46f90b7d8b4a77410b7b05160b0ca8978c15a/izulu-0.50.0-py3-none-any.whl", hash = "sha256:4e9ae2508844e7c5f62c468a8b9e2deba2f60325ef63f01e65b39fd9a6b3fab4", size = 18095, upload-time = "2025-03-24T15:52:19.667Z" },
 ]
 
 [[package]]
@@ -1473,10 +1505,8 @@ name = "pyagenity"
 version = "0.1.7"
 source = { editable = "." }
 dependencies = [
-    { name = "fastmcp" },
     { name = "injectq" },
     { name = "litellm" },
-    { name = "mcp" },
     { name = "pydantic" },
     { name = "python-dotenv" },
 ]
@@ -1489,6 +1519,14 @@ all-publishers = [
 ]
 kafka = [
     { name = "aiokafka" },
+]
+mcp = [
+    { name = "fastmcp" },
+    { name = "mcp" },
+]
+pg-checkpoint = [
+    { name = "asyncpg" },
+    { name = "redis" },
 ]
 rabbitmq = [
     { name = "aio-pika" },
@@ -1511,16 +1549,18 @@ requires-dist = [
     { name = "aio-pika", marker = "extra == 'rabbitmq'", specifier = ">=9.0.0" },
     { name = "aiokafka", marker = "extra == 'all-publishers'", specifier = ">=0.8.0" },
     { name = "aiokafka", marker = "extra == 'kafka'", specifier = ">=0.8.0" },
-    { name = "fastmcp", specifier = ">=2.11.3" },
-    { name = "injectq", specifier = ">=0.1.0" },
+    { name = "asyncpg", marker = "extra == 'pg-checkpoint'", specifier = ">=0.29.0" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.11.3" },
+    { name = "injectq", specifier = "==0.2.0" },
     { name = "litellm", specifier = ">=1.75.0" },
-    { name = "mcp", specifier = ">=1.13.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.13.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "redis", marker = "extra == 'all-publishers'", specifier = ">=4.2" },
+    { name = "redis", marker = "extra == 'pg-checkpoint'", specifier = ">=4.2" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=4.2" },
 ]
-provides-extras = ["redis", "kafka", "rabbitmq", "all-publishers"]
+provides-extras = ["pg-checkpoint", "mcp", "redis", "kafka", "rabbitmq", "all-publishers"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1537,15 +1577,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
-]
-
-[[package]]
-name = "pycron"
-version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/5d/340be12ae4a69c33102dfb6ddc1dc6e53e69b2d504fa26b5d34a472c3057/pycron-3.2.0.tar.gz", hash = "sha256:e125a28aca0295769541a40633f70b602579df48c9cb357c36c28d2628ba2b13", size = 4248, upload-time = "2025-06-05T13:24:12.636Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/76/caf316909f4545e7158e0e1defd8956a1da49f4af04f5d16b18c358dfeac/pycron-3.2.0-py3-none-any.whl", hash = "sha256:6d2349746270bd642b71b9f7187cf13f4d9ee2412b4710396a507b5fe4f60dac", size = 4904, upload-time = "2025-06-05T13:24:11.477Z" },
 ]
 
 [[package]]
@@ -1758,15 +1789,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]
@@ -2169,35 +2191,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
-]
-
-[[package]]
-name = "taskiq"
-version = "0.11.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "importlib-metadata" },
-    { name = "izulu" },
-    { name = "packaging" },
-    { name = "pycron" },
-    { name = "pydantic" },
-    { name = "pytz" },
-    { name = "taskiq-dependencies" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/4d/0d1b3b6c77a45d7a8c685a9c916b2532cca36a26771831949b874f6d15c3/taskiq-0.11.18.tar.gz", hash = "sha256:b83e1b70aee74d0a197d4a4a5ba165b8ba85b12a2b3b7ebfa3c6fdcc9e3128a7", size = 54323, upload-time = "2025-07-15T16:25:54.37Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/d5/46505f57c140d10d4c36f6bd2f2047fb0460e4d5b9b841dc3b93ab8c893d/taskiq-0.11.18-py3-none-any.whl", hash = "sha256:0df58be24e4ef5d19c8ef02581d35d392b0d780d3fe37950e0478022b85ce288", size = 79608, upload-time = "2025-07-15T16:25:52.707Z" },
-]
-
-[[package]]
-name = "taskiq-dependencies"
-version = "1.5.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/90/47a627696e53bfdcacabc3e8c05b73bf1424685bcb5f17209cb8b12da1bf/taskiq_dependencies-1.5.7.tar.gz", hash = "sha256:0d3b240872ef152b719153b9526d866d2be978aeeaea6600e878414babc2dcb4", size = 14875, upload-time = "2025-02-26T22:07:39.876Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/6d/4a012f2de002c2e93273f5e7d3e3feea02f7fdbb7b75ca2ca1dd10703091/taskiq_dependencies-1.5.7-py3-none-any.whl", hash = "sha256:6fcee5d159bdb035ef915d4d848826169b6f06fe57cc2297a39b62ea3e76036f", size = 13801, upload-time = "2025-02-26T22:07:38.622Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces significant improvements to dependency injection, node execution, and agent graph configuration across several example scripts and core framework files. The main changes focus on adopting the `InjectQ` dependency injection system more consistently, refactoring node and graph initialization to support injected dependencies, and updating example agents to demonstrate these new capabilities.

### Dependency Injection and Graph Initialization

* Refactored `StateGraph` to accept and configure a dependency injection container (`InjectQ`) during initialization, ensuring that singletons like `BasePublisher`, `BaseContextManager`, and `BaseIDGenerator` are properly registered and available for injection throughout the graph. The setup logic now uses `bind_instance` and `bind_factory` for flexible dependency management. [[1]](diffhunk://#diff-376b8dc1397bd7190ca855b6ce530ae4ee4d7947469708682381b9b6a233f6abL64-L67) [[2]](diffhunk://#diff-376b8dc1397bd7190ca855b6ce530ae4ee4d7947469708682381b9b6a233f6abL113-R136) [[3]](diffhunk://#diff-376b8dc1397bd7190ca855b6ce530ae4ee4d7947469708682381b9b6a233f6abL139-R168)

* Updated `Node` class to accept injected dependencies via the constructor, replacing manual publisher assignment with `Inject[BasePublisher]`. The node execution method signature was also changed to require explicit `CallbackManager` injection, and the `@inject` decorator was removed for consistency with the new DI approach. [[1]](diffhunk://#diff-45b7d91e0c937fea421458c44b15d80bce1aeb6753d679c44d0154673a77d884L50-R53) [[2]](diffhunk://#diff-45b7d91e0c937fea421458c44b15d80bce1aeb6753d679c44d0154673a77d884L275-R275)

### Example Agent and Tool Refactoring

* Added new example scripts (`react_di.py`, `react_di2.py`) that demonstrate dependency injection for agent state, tool call IDs, checkpointer, and callback manager. These examples showcase how to use `InjectQ` for parameter injection and how to structure agent graphs using the latest DI patterns. [[1]](diffhunk://#diff-ea45e6bfc64ffed0e9e1f591c6c5c64c6d0cd36c64d8e32af6bb6da4a5850596R1-R154) [[2]](diffhunk://#diff-82d5092114a0f5ccb3c1f5f3dfb74e5d8968c9231a950b59e75900264d72d14bR1-R158)

* Refactored existing examples (`react_weather_agent.py`, `stream_react_agent.py`) to remove legacy injection patterns and update function signatures to use direct dependency injection, improving clarity and maintainability. [[1]](diffhunk://#diff-92c73e803788a245bb6a7b8853eb85c1a64e517413be5c0dafac86ab2b06407aL1-L4) [[2]](diffhunk://#diff-92c73e803788a245bb6a7b8853eb85c1a64e517413be5c0dafac86ab2b06407aL20) [[3]](diffhunk://#diff-89ea91660aab846580f5753c8f61d06467fa2e1d3dfec1c0cabd2201df784287L14) [[4]](diffhunk://#diff-89ea91660aab846580f5753c8f61d06467fa2e1d3dfec1c0cabd2201df784287L24-R24)

### Node Execution and Callback Management

* Standardized node execution to require a `CallbackManager` parameter, ensuring callback hooks are consistently managed and available for all node executions. Minor logging and type hinting improvements were also made for better debugging and developer experience. [[1]](diffhunk://#diff-45b7d91e0c937fea421458c44b15d80bce1aeb6753d679c44d0154673a77d884L275-R275) [[2]](diffhunk://#diff-45b7d91e0c937fea421458c44b15d80bce1aeb6753d679c44d0154673a77d884R238) [[3]](diffhunk://#diff-45b7d91e0c937fea421458c44b15d80bce1aeb6753d679c44d0154673a77d884L287-L288)

### Streaming and Invocation Improvements

* Updated streaming and invocation handlers to ensure a default `user_id` is present in the configuration, improving traceability and consistency for agent invocations. [[1]](diffhunk://#diff-52a49e3ee9bbf9dbb84f6b93d47168e305a9829a3c2b62ba46b445b6123ad7f4R127-R128) [[2]](diffhunk://#diff-52a49e3ee9bbf9dbb84f6b93d47168e305a9829a3c2b62ba46b445b6123ad7f4R203-R204)

### Miscellaneous Cleanups

* Cleaned up imports and removed unused or redundant code in several files, including callback validation and invocation handler modules. [[1]](diffhunk://#diff-edd5d1a45662077bb6ac4b8c39152a4a7c31955ded4d8124e7938dc0c2e98306R14-R23) [[2]](diffhunk://#diff-eb3e4b6855874563f693563296c1f9f4acf11a7a26c22c198fd8fa36450860daL13-L16) [[3]](diffhunk://#diff-eb3e4b6855874563f693563296c1f9f4acf11a7a26c22c198fd8fa36450860daL193-R191)

---

**References:**  
[[1]](diffhunk://#diff-376b8dc1397bd7190ca855b6ce530ae4ee4d7947469708682381b9b6a233f6abL64-L67) [[2]](diffhunk://#diff-376b8dc1397bd7190ca855b6ce530ae4ee4d7947469708682381b9b6a233f6abL113-R136) [[3]](diffhunk://#diff-376b8dc1397bd7190ca855b6ce530ae4ee4d7947469708682381b9b6a233f6abL139-R168) [[4]](diffhunk://#diff-45b7d91e0c937fea421458c44b15d80bce1aeb6753d679c44d0154673a77d884L50-R53) [[5]](diffhunk://#diff-45b7d91e0c937fea421458c44b15d80bce1aeb6753d679c44d0154673a77d884L275-R275) [[6]](diffhunk://#diff-ea45e6bfc64ffed0e9e1f591c6c5c64c6d0cd36c64d8e32af6bb6da4a5850596R1-R154) [[7]](diffhunk://#diff-82d5092114a0f5ccb3c1f5f3dfb74e5d8968c9231a950b59e75900264d72d14bR1-R158) [[8]](diffhunk://#diff-92c73e803788a245bb6a7b8853eb85c1a64e517413be5c0dafac86ab2b06407aL1-L4) [[9]](diffhunk://#diff-92c73e803788a245bb6a7b8853eb85c1a64e517413be5c0dafac86ab2b06407aL20) [[10]](diffhunk://#diff-89ea91660aab846580f5753c8f61d06467fa2e1d3dfec1c0cabd2201df784287L14) [[11]](diffhunk://#diff-89ea91660aab846580f5753c8f61d06467fa2e1d3dfec1c0cabd2201df784287L24-R24) [[12]](diffhunk://#diff-45b7d91e0c937fea421458c44b15d80bce1aeb6753d679c44d0154673a77d884R238) [[13]](diffhunk://#diff-45b7d91e0c937fea421458c44b15d80bce1aeb6753d679c44d0154673a77d884L287-L288) [[14]](diffhunk://#diff-52a49e3ee9bbf9dbb84f6b93d47168e305a9829a3c2b62ba46b445b6123ad7f4R127-R128) [[15]](diffhunk://#diff-52a49e3ee9bbf9dbb84f6b93d47168e305a9829a3c2b62ba46b445b6123ad7f4R203-R204) [[16]](diffhunk://#diff-edd5d1a45662077bb6ac4b8c39152a4a7c31955ded4d8124e7938dc0c2e98306R14-R23) [[17]](diffhunk://#diff-eb3e4b6855874563f693563296c1f9f4acf11a7a26c22c198fd8fa36450860daL13-L16) [[18]](diffhunk://#diff-eb3e4b6855874563f693563296c1f9f4acf11a7a26c22c198fd8fa36450860daL193-R191)